### PR TITLE
fix: ルート直下ページのプレゼンモードリンクを修正

### DIFF
--- a/src/components/BottomBar.astro
+++ b/src/components/BottomBar.astro
@@ -11,8 +11,9 @@ const { title, slug } = Astro.props;
 const siteUrl = 'https://slidoc.vercel.app';
 const pageUrl = `${siteUrl}/${slug}/`;
 
-// カテゴリindexページの場合は /present/tech/index/ のようにする
-const isCategory = slug && !slug.includes('/');
+// カテゴリindexページ（howto, tech）の場合は /present/tech/index/ のようにする
+const categoryFolders = ['howto', 'tech'];
+const isCategory = categoryFolders.includes(slug);
 const presentSlug = isCategory ? `${slug}/index` : slug;
 const presentUrl = `/present/${presentSlug}/`;
 


### PR DESCRIPTION
## 概要
`/about/` などルート直下のページでプレゼンモードボタンのリンクが
`/present/about/index/` になり404になっていた問題を修正。

## 変更内容
- BottomBar.astroの`isCategory`判定をカテゴリフォルダの明示的リストに変更
 
 Fixes #4