### PR TITLE
refactor: RESTfulなURL設計に変更 (/present/→/slide/)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(tree:*)",
+      "Bash(cat:*)",
+      "Bash(mkdir:*)",
+      "Bash(npm run build:*)",
+      "Bash(npx astro build)",
+      "Bash(npm install)"
+    ]
+  }
+}

--- a/src/components/BottomBar.astro
+++ b/src/components/BottomBar.astro
@@ -1,6 +1,7 @@
 ---
 import ShareButtons from './ShareButtons.astro';
 import Giscus from './Giscus.astro';
+import { getFullUrl } from '../utils/urls';
 
 interface Props {
   title: string;
@@ -8,8 +9,7 @@ interface Props {
 }
 
 const { title, slug } = Astro.props;
-const siteUrl = 'https://slidoc.vercel.app';
-const pageUrl = `${siteUrl}/${slug}/`;
+const pageUrl = getFullUrl(slug);
 ---
 
 <div class="bottom-bar">

--- a/src/components/PresentFab.astro
+++ b/src/components/PresentFab.astro
@@ -1,22 +1,18 @@
 ---
+import { getSlideUrl, shouldShowSlideLink } from '../utils/urls';
+
 interface Props {
   slug: string;
 }
 
 const { slug } = Astro.props;
 
-// カテゴリindexページ（howto, tech）の場合は /present/tech/index/ のようにする
-const categoryFolders = ['howto', 'tech'];
-const isCategory = categoryFolders.includes(slug);
-const presentSlug = isCategory ? `${slug}/index` : slug;
-const presentUrl = `/present/${presentSlug}/`;
-
-// index ページはプレゼンモードリンクを表示しない
-const showPresentLink = slug !== '' && slug !== 'index' && !slug.endsWith('/index');
+const slideUrl = getSlideUrl(slug);
+const showSlideLink = shouldShowSlideLink(slug);
 ---
 
-{showPresentLink && (
-  <a href={presentUrl} class="present-fab" title="プレゼンモードで開く">
+{showSlideLink && (
+  <a href={slideUrl} class="present-fab" title="スライドモードで開く">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
       <path d="M18 4v5H6V4h12m0-2H6c-1.1 0-2 .9-2 2v5c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 13v5H6v-5h12m0-2H6c-1.1 0-2 .9-2 2v5c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-5c0-1.1-.9-2-2-2z"/>
     </svg>

--- a/src/config/categories.ts
+++ b/src/config/categories.ts
@@ -1,0 +1,24 @@
+/**
+ * カテゴリ設定の一元管理
+ */
+export const CATEGORIES = {
+  howto: {
+    label: '使い方',
+    slug: 'howto',
+  },
+  tech: {
+    label: 'Tech',
+    slug: 'tech',
+  },
+} as const;
+
+export type CategoryKey = keyof typeof CATEGORIES;
+
+export const CATEGORY_SLUGS = Object.values(CATEGORIES).map((c) => c.slug);
+
+/**
+ * 指定されたslugがカテゴリかどうかを判定
+ */
+export function isCategory(slug: string): boolean {
+  return CATEGORY_SLUGS.includes(slug);
+}

--- a/src/pages/[...slug]/slide.astro
+++ b/src/pages/[...slug]/slide.astro
@@ -2,6 +2,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { marked } from 'marked';
+import { getPageUrlFromSlide } from '../../utils/urls';
+import { isCategory } from '../../config/categories';
 
 export async function getStaticPaths() {
   const docsDir = path.join(process.cwd(), 'src/content/docs');
@@ -15,9 +17,14 @@ export async function getStaticPaths() {
       if (stat.isDirectory()) {
         scanDir(fullPath, prefix ? `${prefix}/${file}` : file);
       } else if (file.endsWith('.mdx') || file.endsWith('.md')) {
-        const slug = prefix ? `${prefix}/${file.replace(/\.(mdx?|md)$/, '')}` : file.replace(/\.(mdx?|md)$/, '');
+        const baseName = file.replace(/\.(mdx?|md)$/, '');
+        let slug = prefix ? `${prefix}/${baseName}` : baseName;
         // Skip root index only
         if (slug === 'index') continue;
+        // カテゴリindexは /howto/index ではなく /howto にする
+        if (baseName === 'index' && prefix) {
+          slug = prefix;
+        }
         paths.push({
           params: { slug },
           props: { filePath: fullPath, title: slug },
@@ -112,9 +119,9 @@ slidesHtml = slidesHtml.map(html => {
 });
 
 const filteredSlidesHtml = slidesHtml.filter(html => html.trim());
-// tech/index -> /tech/, about -> /about/
-const docSlug = slug.endsWith('/index') ? slug.replace(/\/index$/, '') : slug;
-const docUrl = `/${docSlug}/`;
+
+// 戻り先URLをユーティリティ関数で取得
+const docUrl = getPageUrlFromSlide(slug);
 ---
 
 <!DOCTYPE html>
@@ -122,7 +129,7 @@ const docUrl = `/${docSlug}/`;
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{title} - プレゼンモード | Slidoc</title>
+  <title>{title} - スライド | Slidoc</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/reset.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/reveal.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/theme/black.css">

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,0 +1,72 @@
+/**
+ * URL生成ユーティリティ
+ * すべてのURL生成を一元管理
+ */
+
+import { isCategory } from '../config/categories';
+
+export const SITE_URL = 'https://slidoc.vercel.app';
+
+/**
+ * パスを正規化する
+ * - 先頭・末尾のスラッシュを削除
+ * - 連続スラッシュを正規化
+ */
+export function normalizeSlug(pathname: string): string {
+  return pathname
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\/+/g, '/')
+    .trim();
+}
+
+/**
+ * 通常ページのURLを取得
+ * @example getPageUrl('howto/getting-started') => '/howto/getting-started/'
+ */
+export function getPageUrl(slug: string): string {
+  const normalized = normalizeSlug(slug);
+  if (!normalized) return '/';
+  return `/${normalized}/`;
+}
+
+/**
+ * スライドページのURLを取得
+ * @example getSlideUrl('howto/getting-started') => '/howto/getting-started/slide/'
+ * @example getSlideUrl('howto') => '/howto/slide/' (カテゴリindex)
+ */
+export function getSlideUrl(slug: string): string {
+  const normalized = normalizeSlug(slug);
+  if (!normalized) return '/';
+  return `/${normalized}/slide/`;
+}
+
+/**
+ * スライドURLから通常ページURLを取得
+ * @example getPageUrlFromSlide('howto/getting-started') => '/howto/getting-started/'
+ * @example getPageUrlFromSlide('howto/index') => '/howto/'
+ */
+export function getPageUrlFromSlide(slug: string): string {
+  const normalized = normalizeSlug(slug);
+  // index付きのslugは親カテゴリにリダイレクト
+  const pageSlug = normalized.endsWith('/index')
+    ? normalized.replace(/\/index$/, '')
+    : normalized;
+  return getPageUrl(pageSlug);
+}
+
+/**
+ * フルURLを取得（シェア用など）
+ */
+export function getFullUrl(slug: string): string {
+  return `${SITE_URL}${getPageUrl(slug)}`;
+}
+
+/**
+ * プレゼンリンクを表示すべきかどうかを判定
+ */
+export function shouldShowSlideLink(slug: string): boolean {
+  const normalized = normalizeSlug(slug);
+  // ホームページ、空、カテゴリindexでは非表示
+  return normalized !== '' && normalized !== 'index' && !normalized.endsWith('/index');
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/present/:path*",
+      "destination": "/:path*/slide/",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
- スライドURLを /present/xxx/ から /xxx/slide/ に変更
- URL生成ロジックをsrc/utils/urls.tsに一元化
- カテゴリ設定をsrc/config/categories.tsに集約
- 旧URLからのリダイレクト設定を追加 (vercel.json)